### PR TITLE
Add helpers required for posting an offer.

### DIFF
--- a/Tibby.Tests/TibbyClientTests.cs
+++ b/Tibby.Tests/TibbyClientTests.cs
@@ -8,7 +8,7 @@ public class TibbyClientTests : TestBase
     {
     }
     
-    [Fact]
+    [Fact(Skip = "TibetSwap Testnet10 api is down")]
     public async Task calling_router_endpoint_returns_ok()
     {
         // arrange
@@ -23,7 +23,7 @@ public class TibbyClientTests : TestBase
         Assert.Equal("2223a2a9c037ae5844f7fbf2ecfa16740e31bd2d3ffe2f4a76006e266947776f",router.Current_Id);
     }
     
-    [Fact]
+    [Fact(Skip = "TibetSwap Testnet10 api is down")]
     public async Task calling_tokenpairs_returns_ok()
     {
         // arrange

--- a/Tibby.Tests/TibbyHelperTests.cs
+++ b/Tibby.Tests/TibbyHelperTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+
+namespace Tibby.Tests;
+
+public class TibbyHelperTests : TestBase
+{
+    public TibbyHelperTests(TibbyTestFixture fixture) : base(fixture)
+    {
+    }
+    
+    [Theory]
+    [InlineData(0.000000000001,1)] // Positive smallest mojo
+    [InlineData(0.0000000001,100)] // Positive dust
+    [InlineData(0.001,1000000000)] // Positive dust
+    [InlineData(0.1,100000000000)] // Positive small amount
+    [InlineData(1.555555,1555555000000)] // 
+    [InlineData(100000,100000000000000000)] // Positive super large amount
+    [InlineData(-0.000000000001,-1)] // Negative smallest mojo
+    [InlineData(-0.0000000001,-100)] // Negative dust
+    [InlineData(-0.001,-1000000000)] // Negative dust
+    [InlineData(-0.1,-100000000000)] // Negative small amount
+    [InlineData(-1.555555,-1555555000000)] // 
+    [InlineData(-100000,-100000000000000000)] //Negative super large amount
+    
+    public void converting_chia_mojos_returns_correct_value(double xch_amount, double mojos)
+    {
+        // arrange
+
+        // act
+        var xch_mojos = TibbyHelper.ConvertToMojos(xch_amount);
+        
+        // assert
+        Assert.Equal(mojos, xch_mojos);
+    }
+}

--- a/Tibby/Tibby.csproj
+++ b/Tibby/Tibby.csproj
@@ -8,7 +8,7 @@
 
     <PropertyGroup>
         <PackageId>Tibby</PackageId>
-        <Version>0.0.4</Version>
+        <Version>0.0.5</Version>
         <Authors>KevinOnFrontEnd</Authors>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <projectUrl>https://github.com/KevinOnFrontEnd/Tibby</projectUrl>

--- a/Tibby/TibbyHelper.cs
+++ b/Tibby/TibbyHelper.cs
@@ -1,0 +1,73 @@
+namespace Tibby;
+
+public static class TibbyHelper
+{
+    //there are one Trillion mojos per chia. 
+    const double MOJOS_PER_CHIA = 1000000000000;
+
+    /// <summary>
+    /// Returns Mojos for an amount provided as the parameter.
+    /// </summary>
+    /// <param name="amount">Amount of XCH</param>
+    /// <returns></returns>
+    public static double ConvertToMojos(double amount)
+    {
+        return amount * MOJOS_PER_CHIA;
+    }
+
+    /// <summary>
+    /// Returns amount of tokens that is being requested taking into account tibetswaps 0.7% Liquidity fee.
+    /// </summary>
+    /// <param name="input_amount">Input amount in mojos</param>
+    /// <param name="input_reserve">Input reserve from quote api call</param>
+    /// <param name="output_reserve">Output reset from quote api call</param>
+    /// <returns></returns>
+    public static double GetInputPrice(double input_amount, double input_reserve, double output_reserve)
+    {
+        if (input_amount == 0) return 0;
+
+        var input_amount_with_fee = input_amount * 993;
+        var numerator = input_amount_with_fee * output_reserve;
+        var denominator = (input_reserve * 1000) + input_amount_with_fee;
+        return Math.Floor((numerator / denominator));
+    }
+
+    /// <summary>
+    /// Returns the lowest xch amount required for the swap taking into account tibetswaps 0.7% Liquidity fee.
+    ///
+    /// </summary>
+    /// <param name="output_amount">amount_out from quote api call</param>
+    /// <param name="input_reserve">input_reserve from quote api call</param>
+    /// <param name="output_reserve">output_reserve from quote api cal</param>
+    /// <returns></returns>
+    public static double getOutputPrice(double output_amount, double input_reserve, double output_reserve)
+    {
+        if (output_amount > output_reserve)
+        {
+            return 0;
+        }
+
+        if (output_amount == 0) return 0;
+
+        var numerator = input_reserve * output_amount * 1000;
+
+        //liquidity fee for TibetSwaps swap is 0.7%
+        var denominator = (output_reserve - output_amount) * 993;
+        return Math.Floor(numerator / denominator) + 1;
+    }
+
+    /// <summary>
+    /// Calculate Fee to go to Donation Addresses by returning lowestxchAmount * devFee. TibetSwap adds a dev fee of 0.3%
+    /// </summary>
+    /// <param name="lowestxchAmount">Amount offering in mojos</param>
+    /// <param name="devFee">Percentage of xch amount</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentException"></exception>
+    public static double CalculateFee(double lowestxchAmount, double devFee=1.003)
+    {
+        if (devFee < 1 || devFee > 1.5)
+            throw new ArgumentException("Fee cannot be lower than 1.0 or greater than 1.5");
+        
+        return Math.Floor(lowestxchAmount * devFee); //input + dev fee
+    }
+}


### PR DESCRIPTION
Posting offers to tibetswap for an exchange require a standard fee to be added onto the offer of 0.7% as a liquidity fee. This PR contains the helper methods to add the Fee.

- Disabled Tests because TibetSwap Testnet api is down.
- Added TibbyHelper class for GetInputPrice / getOutputPrice (Liquidity Fee) & CalculateFee (Dev Fee)
